### PR TITLE
feat(events): add event deletion

### DIFF
--- a/src/lib/components/events/EventDetailsHeader.svelte
+++ b/src/lib/components/events/EventDetailsHeader.svelte
@@ -3,6 +3,18 @@
 	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
 	import { Badge } from '../ui/badge';
 	import { Button } from '../ui/button';
+	import {
+		Root as AlertDialog,
+		Trigger as AlertDialogTrigger,
+		Content as AlertDialogContent,
+		Header as AlertDialogHeader,
+		Title as AlertDialogTitle,
+		Description as AlertDialogDescription,
+		Footer as AlertDialogFooter,
+		Cancel as AlertDialogCancel,
+		Action as AlertDialogAction
+	} from '../ui/alert-dialog';
+	import { buttonVariants } from '../ui/button/button.svelte';
 	import { badgeColors, eventBewerbungMoeglich } from '@/utils/utils';
 	import { superForm } from 'sveltekit-superforms/client';
 	import { zodClient } from 'sveltekit-superforms/adapters';
@@ -48,7 +60,7 @@
 		onResult: async ({ result }) => {
 			handleActionResultSonners(result, 'delete_event_form');
 			if (result.status !== 500 && result.type === 'success') {
-				await goto('../', { replaceState: true });
+				await goto('../events', { replaceState: true });
 			}
 		}
 	});
@@ -138,10 +150,34 @@
 				<a href={`./${eventData.ID}/besetzen`}>
 					<Button variant="default">Bewerbungen & Besetzung</Button>
 				</a>
-				<form method="POST" use:deleteEventForm.enhance class="inline">
-					<input type="hidden" name="ID" bind:value={$deleteEventFormData.ID} />
-					<Button variant="destructive" formaction="?/deleteEvent">Event löschen</Button>
-				</form>
+				<!-- Delete confirmation dialog -->
+				<AlertDialog>
+					<AlertDialogTrigger class={buttonVariants({ variant: 'destructive' })} type="button">
+						Event löschen
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Event wirklich löschen?</AlertDialogTitle>
+							<AlertDialogDescription>
+								Diese Aktion kann nicht rückgängig gemacht werden. Das Event und alle abhängigen
+								Daten (z.B. Bewerbungen, Besetzungen) werden dauerhaft entfernt.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Abbrechen</AlertDialogCancel>
+							<form method="POST" use:deleteEventForm.enhance class="inline">
+								<input type="hidden" name="ID" bind:value={$deleteEventFormData.ID} />
+								<AlertDialogAction
+									class={buttonVariants({ variant: 'destructive' })}
+									type="submit"
+									formaction="?/deleteEvent"
+								>
+									Event löschen
+								</AlertDialogAction>
+							</form>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
 			{/if}
 			{#if !(showApplyOrEditButton || (isUserEventResponsible && showApplyOrEditButton))}
 				<!-- Unsichtbarer Platzhalter, falls absolut keine Buttons -->

--- a/src/lib/schemas/eventDeleteSchema.ts
+++ b/src/lib/schemas/eventDeleteSchema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const eventDeleteSchema = z.object({
+	ID: z.number().min(1)
+});
+
+export type EventDeleteSchema = z.infer<typeof eventDeleteSchema>;

--- a/src/lib/server/sharepoint/events.server.ts
+++ b/src/lib/server/sharepoint/events.server.ts
@@ -46,6 +46,11 @@ export async function deleteEventMaster(id: number) {
 	return await EventMasterList.delete(id);
 }
 
+export async function deleteEvent(id: number) {
+	const EventList = new SharepointList('4_Events');
+	return await EventList.delete(id);
+}
+
 export async function createNewEvent(data: EventData) {
 	const EventList = new SharepointList('4_Events');
 	//transformData

--- a/src/lib/server/sharepoint/events.server.ts
+++ b/src/lib/server/sharepoint/events.server.ts
@@ -48,7 +48,22 @@ export async function deleteEventMaster(id: number) {
 
 export async function deleteEvent(id: number) {
 	const EventList = new SharepointList('4_Events');
-	return await EventList.delete(id);
+	const EventVerantwortlicheList = new SharepointList('4_EventVerantwortliche');
+	const EventBewerbungenList = new SharepointList('4_EventBewerbungen');
+
+	const eventResult = await EventList.delete(id);
+	if (eventResult instanceof Error) return eventResult;
+
+	const eventVerantwortlicheResult = await EventVerantwortlicheList.deleteAllWhereEquals(
+		'EventID',
+		id
+	);
+	if (eventVerantwortlicheResult instanceof Error) return eventVerantwortlicheResult;
+
+	const eventBewerbungenResult = await EventBewerbungenList.deleteAllWhereEquals('EventID', id);
+	if (eventBewerbungenResult instanceof Error) return eventBewerbungenResult;
+
+	return null;
 }
 
 export async function createNewEvent(data: EventData) {

--- a/src/lib/server/sharepoint/list.server.ts
+++ b/src/lib/server/sharepoint/list.server.ts
@@ -69,6 +69,22 @@ class SharepointList {
 		}
 	}
 
+	public async deleteAllWhereEquals(fieldName: string, value: string | number) {
+		try {
+			const client = await getGraphClient();
+			const response = await client
+				.api(`${this.databaseUrl}${this.listId}/items?$filter=fields/${fieldName} eq '${value}'`)
+				.get();
+			if (response.value && response.value.length > 0) {
+				for (const item of response.value) {
+					await this.delete(item.id);
+				}
+			}
+		} catch (error: any) {
+			return new Error('Sharepoint Delete Error');
+		}
+	}
+
 	// Returns the list's columns (fields). Set includeHidden=false to exclude hidden columns.
 	public async getFields(includeHidden: boolean = true) {
 		try {

--- a/src/lib/server/supabase/events.server.ts
+++ b/src/lib/server/supabase/events.server.ts
@@ -36,6 +36,11 @@ export async function deleteEventApplication(id: number) {
 	return error;
 }
 
+export async function deleteEvent(id: number) {
+	const { error } = await supabaseServerClient().from('4_Events').delete().eq('ID', id);
+	return error;
+}
+
 export async function updateEventMaster(formData: EventMasterForm) {
 	const { error } = await supabaseServerClient()
 		.from('4_EventMaster')

--- a/src/lib/server/supabase/events.server.ts
+++ b/src/lib/server/supabase/events.server.ts
@@ -37,8 +37,19 @@ export async function deleteEventApplication(id: number) {
 }
 
 export async function deleteEvent(id: number) {
-	const { error } = await supabaseServerClient().from('4_Events').delete().eq('ID', id);
-	return error;
+	const { error: eventError } = await supabaseServerClient().from('4_Events').delete().eq('ID', id);
+	if (eventError) return eventError;
+	const { error: eventVerantwortlicheError } = await supabaseServerClient()
+		.from('4_EventVerantwortliche')
+		.delete()
+		.eq('EventID', id);
+	if (eventVerantwortlicheError) return eventVerantwortlicheError;
+	const { error: eventBewerbungenError } = await supabaseServerClient()
+		.from('4_EventBewerbungen')
+		.delete()
+		.eq('EventID', id);
+	if (eventBewerbungenError) return eventBewerbungenError;
+	return null;
 }
 
 export async function updateEventMaster(formData: EventMasterForm) {

--- a/src/routes/app/events/[eventId]/+layout.server.ts
+++ b/src/routes/app/events/[eventId]/+layout.server.ts
@@ -1,6 +1,4 @@
-import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
-import { error as svelteError } from '@sveltejs/kit';
 import { throwMissingErrorIfNeeded } from '@/utils/utils.server';
 import {
 	getEventApplicationState,
@@ -8,6 +6,9 @@ import {
 	getEventTitleImage,
 	getNumberOfEventApplications
 } from '@/server/supabase/events.server';
+import { superValidate } from 'sveltekit-superforms/server';
+import { zod } from 'sveltekit-superforms/adapters';
+import { eventDeleteSchema } from '@/schemas/eventDeleteSchema';
 
 export const load: LayoutServerLoad = async ({ locals, params }) => {
 	const eventId = throwMissingErrorIfNeeded(params.eventId);
@@ -17,12 +18,14 @@ export const load: LayoutServerLoad = async ({ locals, params }) => {
 	const applicationState = await getEventApplicationState(Number(eventId), userId);
 	const totalApplications = await getNumberOfEventApplications(Number(eventId));
 	const eventImageUrl = await getEventTitleImage(Number(eventId));
+	const deleteForm = await superValidate({ ID: Number(eventId) }, zod(eventDeleteSchema));
 
 	return {
 		userId,
 		eventData: eventData,
 		applicationState: applicationState.length > 0 ? applicationState[0] : null,
 		totalApplications,
-		eventImageUrl
+		eventImageUrl,
+		deleteForm
 	};
 };

--- a/src/routes/app/events/[eventId]/+layout.svelte
+++ b/src/routes/app/events/[eventId]/+layout.svelte
@@ -28,6 +28,7 @@
 		totalApplications={data.totalApplications}
 		showApplyOrEditButton={!isBewerbenPage}
 		eventImageUrl={data.eventImageUrl}
+		deleteForm={data.deleteForm}
 	/>
 	{@render children()}
 {/await}


### PR DESCRIPTION
## Summary
- allow event removal from Supabase and SharePoint
- wire EventDetailsHeader delete button to server action with toast feedback
- add schema and layout wiring for delete form

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf38ef9ce08328b124161d27790a24