### PR TITLE
feat: add global feedback dialog

### DIFF
--- a/src/lib/components/feedback/FeedbackDialog.svelte
+++ b/src/lib/components/feedback/FeedbackDialog.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import {
+		Dialog,
+		DialogContent,
+		DialogHeader,
+		DialogTitle,
+		DialogTrigger,
+		DialogFooter,
+		DialogClose
+	} from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Textarea } from '$lib/components/ui/textarea';
+	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
+	import { MessageSquare } from 'lucide-svelte';
+	import { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { feedbackSchema, feedbackCategories, type FeedbackForm } from '@/schemas/feedbackSchema';
+	import { toast } from 'svelte-sonner';
+	import { handleActionResultSonners } from '@/app.utils';
+	import { page } from '$app/stores';
+	import type { SuperValidated } from 'sveltekit-superforms';
+
+	const { form: initialForm } = $props<{ form: SuperValidated<FeedbackForm> }>();
+
+	const form = superForm(initialForm, {
+		validators: zodClient(feedbackSchema),
+		dataType: 'json',
+		onSubmit: () => {
+			toast.loading('Feedback wird gesendet', { id: 'feedback_form' });
+		},
+		onResult: ({ result }) => {
+			handleActionResultSonners(result, 'feedback_form');
+			if (result.type === 'success') {
+				open = false;
+			}
+		}
+	});
+
+	const formData = form.form;
+	let open = false;
+
+	function prepareFeedback() {
+		form.reset();
+		formData.AppSeite = $page.url.pathname;
+	}
+</script>
+
+<Dialog bind:open>
+	<DialogTrigger asChild>
+		<Button
+			class="fixed bottom-4 right-4 rounded-full h-12 w-12 p-3 shadow-lg"
+			on:click={prepareFeedback}
+		>
+			<MessageSquare class="h-6 w-6" />
+		</Button>
+	</DialogTrigger>
+	<DialogContent class="sm:max-w-[425px]">
+		<DialogHeader>
+			<DialogTitle>Feedback geben</DialogTitle>
+		</DialogHeader>
+		<form method="POST" action="?/sendFeedback" use:form.enhance class="space-y-4">
+			<div class="space-y-2">
+				<Input name="Titel" placeholder="Titel" bind:value={formData.Titel} />
+			</div>
+			<div class="space-y-2">
+				<input type="hidden" name="Kategorie" value={formData.Kategorie} />
+				<Select type="single" bind:value={formData.Kategorie}>
+					<SelectTrigger class="w-full">
+						{formData.Kategorie || 'Kategorie wählen'}
+					</SelectTrigger>
+					<SelectContent>
+						{#each feedbackCategories as cat}
+							<SelectItem value={cat}>{cat}</SelectItem>
+						{/each}
+					</SelectContent>
+				</Select>
+			</div>
+			<div class="space-y-2">
+				<Input name="AppSeite" bind:value={formData.AppSeite} />
+			</div>
+			<div class="space-y-2">
+				<Textarea
+					name="Beschreibung"
+					placeholder="Beschreibung"
+					bind:value={formData.Beschreibung}
+				/>
+			</div>
+			<DialogFooter class="flex justify-end gap-2 pt-2">
+				<DialogClose asChild>
+					<Button type="button" variant="secondary">Abbrechen</Button>
+				</DialogClose>
+				<Button type="submit">Senden</Button>
+			</DialogFooter>
+		</form>
+	</DialogContent>
+</Dialog>

--- a/src/lib/schemas/feedbackSchema.ts
+++ b/src/lib/schemas/feedbackSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const feedbackCategories = ['Bug', 'Feature', 'UI', 'Other'] as const;
+
+export const feedbackSchema = z.object({
+	Titel: z
+		.string({ required_error: 'Titel darf nicht leer sein' })
+		.min(1, 'Titel darf nicht leer sein'),
+	Kategorie: z.enum(feedbackCategories),
+	AppSeite: z
+		.string({ required_error: 'App-Seite darf nicht leer sein' })
+		.min(1, 'App-Seite darf nicht leer sein'),
+	Beschreibung: z
+		.string({ required_error: 'Beschreibung darf nicht leer sein' })
+		.min(1, 'Beschreibung darf nicht leer sein')
+});
+
+export type FeedbackForm = z.infer<typeof feedbackSchema>;

--- a/src/lib/server/supabase/feedback.server.ts
+++ b/src/lib/server/supabase/feedback.server.ts
@@ -1,0 +1,12 @@
+import type { FeedbackForm } from '@/schemas/feedbackSchema';
+import { supabaseServerClient } from './supabaseServerClient.server';
+
+export async function addFeedback(formData: FeedbackForm) {
+	const { error } = await supabaseServerClient().from('Feedback').insert({
+		Titel: formData.Titel,
+		Kategorie: formData.Kategorie,
+		AppSeite: formData.AppSeite,
+		Beschreibung: formData.Beschreibung
+	});
+	return error;
+}

--- a/src/routes/app/+layout.server.ts
+++ b/src/routes/app/+layout.server.ts
@@ -1,11 +1,32 @@
-import { redirect } from '@sveltejs/kit';
-import type { LayoutServerLoad } from './$types';
+import type { Actions, LayoutServerLoad } from './$types';
 import { error as svelteError } from '@sveltejs/kit';
+import { superValidate } from 'sveltekit-superforms/server';
+import { zod } from 'sveltekit-superforms/adapters';
+import { feedbackSchema } from '@/schemas/feedbackSchema';
+import { returnActionResult } from '@/utils/utils.server';
+import { addFeedback } from '@/server/supabase/feedback.server';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	const fullName = locals.user?.user_metadata.full_name;
 
 	if (!fullName) return svelteError(401, 'Unauthorized');
 
-	return { data: { vorname: fullName.split(' ')[0], nachname: fullName.split(' ')[1] } };
+	const feedbackForm = await superValidate(zod(feedbackSchema));
+
+	return {
+		data: { vorname: fullName.split(' ')[0], nachname: fullName.split(' ')[1] },
+		feedbackForm
+	};
+};
+
+export const actions: Actions = {
+	sendFeedback: async ({ request }) => {
+		const form = await superValidate(request, zod(feedbackSchema));
+		return returnActionResult(
+			form,
+			() => addFeedback(form.data),
+			'Fehler beim Senden des Feedbacks',
+			'Feedback erfolgreich gesendet'
+		);
+	}
 };

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -14,6 +14,7 @@
 	import { page } from '$app/stores';
 	import { derived, writable, type Readable } from 'svelte/store';
 	import { setContext } from 'svelte';
+	import FeedbackDialog from '@/components/feedback/FeedbackDialog.svelte';
 
 	let { data, children } = $props();
 
@@ -121,3 +122,5 @@
 		</div>
 	</SidebarInset>
 </SidebarProvider>
+
+<FeedbackDialog form={(data as any).feedbackForm} />


### PR DESCRIPTION
## Summary
- add reusable feedback dialog with floating button and form
- validate feedback with zod and persist via Supabase server action
- hook feedback dialog into app layout for global access

## Testing
- `pnpm lint` *(fails: Code style issues found in 327 files. Run Prettier with --write to fix.)*
- `pnpm check` *(fails: svelte-check found 22 errors and 2 warnings in 9 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b56f17fc8328995aebd35bcdde80