### PR TITLE
feat: add feedback dialog

### DIFF
--- a/src/lib/components/feedback/FeedbackDialog.svelte
+++ b/src/lib/components/feedback/FeedbackDialog.svelte
@@ -11,13 +11,7 @@
 	} from '$lib/components/ui/dialog';
 	import { Input } from '$lib/components/ui/input';
 	import { Textarea } from '$lib/components/ui/textarea';
-	import {
-		Select,
-		SelectContent,
-		SelectItem,
-		SelectTrigger,
-		SelectValue
-	} from '$lib/components/ui/select';
+	import { Select, SelectContent, SelectItem, SelectTrigger } from '$lib/components/ui/select';
 	import { MessageSquare } from 'lucide-svelte';
 	import { page } from '$app/stores';
 	import { toast } from 'svelte-sonner';
@@ -30,18 +24,33 @@
 	let titel = $state('');
 	let kategorie = $state('');
 	let beschreibung = $state('');
+	let prioritaet = $state('');
+	let sending = $state(false);
 
-	const kategorien = ['Bug', 'Feature Request', 'Verbesserung', 'Sonstiges'];
+	const kategorien = ['Bug', 'Feature Request', 'Sonstiges'];
 
-	$: appSeite = $page.url.pathname;
+	const appSeite = $derived($page.url.pathname);
+	const canSend = $derived(
+		titel.trim().length > 0 &&
+			kategorie.trim().length > 0 &&
+			prioritaet.trim().length > 0 &&
+			beschreibung.trim().length > 0
+	);
 
 	async function sendFeedback() {
+		if (!canSend) {
+			toast.error('Bitte alle Felder ausfüllen');
+			return;
+		}
+		if (sending) return;
+		sending = true;
 		toast.loading('Feedback wird gesendet', { id: 'send_feedback' });
-		const { error } = await supabase.from('Feedback').insert({
-			Titel: titel,
-			Kategorie: kategorie,
+		const { error } = await supabase.from('0_UserFeedback').insert({
+			Titel: titel.trim(),
+			Kategorie: kategorie.trim(),
+			Prioritaet: prioritaet.trim(),
 			AppSeite: appSeite,
-			Beschreibung: beschreibung
+			Beschreibung: beschreibung.trim()
 		});
 		if (error) {
 			toast.error('Feedback konnte nicht gesendet werden', { id: 'send_feedback' });
@@ -50,13 +59,15 @@
 			open = false;
 			titel = '';
 			kategorie = '';
+			prioritaet = '';
 			beschreibung = '';
 		}
+		sending = false;
 	}
 </script>
 
 <Dialog bind:open>
-	<DialogTrigger asChild>
+	<DialogTrigger>
 		<Button class="fixed bottom-4 right-4 rounded-full h-12 w-12" variant="default" size="icon">
 			<MessageSquare class="h-5 w-5" />
 			<span class="sr-only">Feedback</span>
@@ -68,23 +79,31 @@
 			<DialogDescription>Teile uns dein Feedback zur aktuellen Seite mit.</DialogDescription>
 		</DialogHeader>
 		<div class="grid gap-4 py-4">
-			<Input placeholder="Titel" bind:value={titel} />
-			<Select bind:value={kategorie}>
-				<SelectTrigger>
-					<SelectValue placeholder="Kategorie" />
-				</SelectTrigger>
+			<Input placeholder="Titel" bind:value={titel} required />
+			<Select type="single" bind:value={kategorie}>
+				<SelectTrigger aria-required="true">{kategorie || 'Kategorie wählen'}</SelectTrigger>
 				<SelectContent>
 					{#each kategorien as k}
 						<SelectItem value={k}>{k}</SelectItem>
 					{/each}
 				</SelectContent>
 			</Select>
+			<Select type="single" bind:value={prioritaet}>
+				<SelectTrigger aria-required="true">{prioritaet || 'Priorität wählen'}</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="Niedrig">Niedrig</SelectItem>
+					<SelectItem value="Mittel">Mittel</SelectItem>
+					<SelectItem value="Hoch">Hoch</SelectItem>
+				</SelectContent>
+			</Select>
 			<Input value={appSeite} readonly />
-			<Textarea rows="4" placeholder="Beschreibung" bind:value={beschreibung} />
+			<Textarea rows={4} placeholder="Beschreibung" bind:value={beschreibung} required />
 		</div>
 		<DialogFooter>
-			<Button type="button" variant="outline" on:click={() => (open = false)}>Abbrechen</Button>
-			<Button type="button" on:click={sendFeedback}>Senden</Button>
+			<Button type="button" variant="outline" onclick={() => (open = false)} disabled={sending}
+				>Abbrechen</Button
+			>
+			<Button type="button" onclick={sendFeedback} disabled={!canSend || sending}>Senden</Button>
 		</DialogFooter>
 	</DialogContent>
 </Dialog>

--- a/src/lib/components/feedback/FeedbackDialog.svelte
+++ b/src/lib/components/feedback/FeedbackDialog.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import {
+		Dialog,
+		DialogContent,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle,
+		DialogDescription,
+		DialogTrigger
+	} from '$lib/components/ui/dialog';
+	import { Input } from '$lib/components/ui/input';
+	import { Textarea } from '$lib/components/ui/textarea';
+	import {
+		Select,
+		SelectContent,
+		SelectItem,
+		SelectTrigger,
+		SelectValue
+	} from '$lib/components/ui/select';
+	import { MessageSquare } from 'lucide-svelte';
+	import { page } from '$app/stores';
+	import { toast } from 'svelte-sonner';
+	import type { SupabaseClient } from '@supabase/supabase-js';
+	import type { Database } from '@/database.types';
+
+	const { supabase } = $props<{ supabase: SupabaseClient<Database> }>();
+
+	let open = $state(false);
+	let titel = $state('');
+	let kategorie = $state('');
+	let beschreibung = $state('');
+
+	const kategorien = ['Bug', 'Feature Request', 'Verbesserung', 'Sonstiges'];
+
+	$: appSeite = $page.url.pathname;
+
+	async function sendFeedback() {
+		toast.loading('Feedback wird gesendet', { id: 'send_feedback' });
+		const { error } = await supabase.from('Feedback').insert({
+			Titel: titel,
+			Kategorie: kategorie,
+			AppSeite: appSeite,
+			Beschreibung: beschreibung
+		});
+		if (error) {
+			toast.error('Feedback konnte nicht gesendet werden', { id: 'send_feedback' });
+		} else {
+			toast.success('Feedback erfolgreich gesendet', { id: 'send_feedback' });
+			open = false;
+			titel = '';
+			kategorie = '';
+			beschreibung = '';
+		}
+	}
+</script>
+
+<Dialog bind:open>
+	<DialogTrigger asChild>
+		<Button class="fixed bottom-4 right-4 rounded-full h-12 w-12" variant="default" size="icon">
+			<MessageSquare class="h-5 w-5" />
+			<span class="sr-only">Feedback</span>
+		</Button>
+	</DialogTrigger>
+	<DialogContent class="sm:max-w-[425px]">
+		<DialogHeader>
+			<DialogTitle>Feedback geben</DialogTitle>
+			<DialogDescription>Teile uns dein Feedback zur aktuellen Seite mit.</DialogDescription>
+		</DialogHeader>
+		<div class="grid gap-4 py-4">
+			<Input placeholder="Titel" bind:value={titel} />
+			<Select bind:value={kategorie}>
+				<SelectTrigger>
+					<SelectValue placeholder="Kategorie" />
+				</SelectTrigger>
+				<SelectContent>
+					{#each kategorien as k}
+						<SelectItem value={k}>{k}</SelectItem>
+					{/each}
+				</SelectContent>
+			</Select>
+			<Input value={appSeite} readonly />
+			<Textarea rows="4" placeholder="Beschreibung" bind:value={beschreibung} />
+		</div>
+		<DialogFooter>
+			<Button type="button" variant="outline" on:click={() => (open = false)}>Abbrechen</Button>
+			<Button type="button" on:click={sendFeedback}>Senden</Button>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>
+
+<style>
+	/* No additional styles */
+</style>

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -14,6 +14,36 @@ export type Database = {
   }
   public: {
     Tables: {
+      "0_UserFeedback": {
+        Row: {
+          AppSeite: string | null
+          Beschreibung: string | null
+          created_at: string
+          ID: number
+          Kategorie: string | null
+          Prioritaet: string | null
+          Titel: string | null
+        }
+        Insert: {
+          AppSeite?: string | null
+          Beschreibung?: string | null
+          created_at?: string
+          ID?: number
+          Kategorie?: string | null
+          Prioritaet?: string | null
+          Titel?: string | null
+        }
+        Update: {
+          AppSeite?: string | null
+          Beschreibung?: string | null
+          created_at?: string
+          ID?: number
+          Kategorie?: string | null
+          Prioritaet?: string | null
+          Titel?: string | null
+        }
+        Relationships: []
+      }
       "1_Mitglieder": {
         Row: {
           Anwaertergeneration: string | null

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -14,6 +14,7 @@
 	import { page } from '$app/stores';
 	import { derived, writable, type Readable } from 'svelte/store';
 	import { setContext } from 'svelte';
+	import FeedbackDialog from '@/components/feedback/FeedbackDialog.svelte';
 
 	let { data, children } = $props();
 
@@ -120,4 +121,5 @@
 			{@render children()}
 		</div>
 	</SidebarInset>
+	<FeedbackDialog supabase={data.supabase} />
 </SidebarProvider>


### PR DESCRIPTION
## Summary
- add floating feedback button with dialog on app pages
- allow users to submit categorized feedback saved to Supabase

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Code style issues found in 322 files)
- `npm run check` (fails: svelte-check found 93 errors and 1 warning in 34 files)


------
https://chatgpt.com/codex/tasks/task_e_68c1c71984c483289ebf9002a26a783e