### PR TITLE
Bootstrap client-side SharePoint auth via Supabase

### DIFF
--- a/src/lib/api/sharepoint/listIds.ts
+++ b/src/lib/api/sharepoint/listIds.ts
@@ -1,6 +1,6 @@
 export const listIds = {
-	'4_EventMaster': '341d123c-20a2-47e7-a9e5-6a9b6ab03446',
-	'4_Events': '52149d47-d825-4179-8711-f892756e8a3c',
-	'4_EventVerantwortliche': 'b966005b-938d-47ef-b9fa-e289807217e2',
-	'4_EventBewerbungen': '0da0c0d3-cf69-4c50-a1bf-16e7916d52fc'
+        '4_EventMaster': '341d123c-20a2-47e7-a9e5-6a9b6ab03446',
+        '4_Events': '52149d47-d825-4179-8711-f892756e8a3c',
+        '4_EventVerantwortliche': 'b966005b-938d-47ef-b9fa-e289807217e2',
+        '4_EventBewerbungen': '0da0c0d3-cf69-4c50-a1bf-16e7916d52fc'
 } as const;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,18 +1,28 @@
 <script lang="ts">
-	import { invalidate } from '$app/navigation';
-	import { onMount, setContext } from 'svelte';
-	import '../app.css';
+        import { browser } from '$app/environment';
+        import { invalidate } from '$app/navigation';
+        import { onMount, setContext } from 'svelte';
+        import '../app.css';
+        import { createSharepointClientStore } from '@/api/sharepoint/sharepointClient';
 
-	let { data, children } = $props();
-	let { supabase, session } = $derived(data);
-	onMount(() => {
-		const { data } = supabase.auth.onAuthStateChange((event, _session) => {
-			if (_session?.expires_at !== session?.expires_at) {
-				invalidate('supabase:auth');
-			}
-		});
-		return () => data.subscription.unsubscribe();
-	});
+        let { data, children } = $props();
+        let { supabase, session } = $derived(data);
+
+        let sharepointClientStore;
+
+        $: if (browser && supabase && !sharepointClientStore) {
+                sharepointClientStore = createSharepointClientStore(supabase);
+                setContext('sharepointClient', sharepointClientStore);
+        }
+
+        onMount(() => {
+                const { data } = supabase.auth.onAuthStateChange((event, _session) => {
+                        if (_session?.expires_at !== session?.expires_at) {
+                                invalidate('supabase:auth');
+                        }
+                });
+                return () => data.subscription.unsubscribe();
+        });
 </script>
 
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 			options: {
 				// use environment variable in production
 				redirectTo: PUBLIC_BASE_URL + '/auth/callback',
-				scopes: 'openid email profile User.Read'
+                                scopes: 'openid email profile offline_access User.Read Sites.ReadWrite.All'
 			}
 		});
 


### PR DESCRIPTION
## Summary
- add a client-side SharePoint Graph client that reuses the current Supabase Microsoft session token and keeps it updated via auth state changes
- expose SharePoint list helpers for browser usage and register the client store on the root layout context
- request delegated SharePoint scopes during Azure sign-in so the Microsoft Graph client can mutate lists from the SPA

## Testing
- `npm run check` *(fails: missing $env module declarations and unrelated component typing issues already present in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb25c0c48328956d7eac12400b1e